### PR TITLE
allow serialization/deserialization where constructor type is assignable from property type

### DIFF
--- a/Recipes.Test/JsonConfiguration/JsonConfigurationTest.cs
+++ b/Recipes.Test/JsonConfiguration/JsonConfigurationTest.cs
@@ -590,7 +590,6 @@ namespace Spritely.Recipes.Test
             public Diet Diet { get; }
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Class is used but is constructed via reflection and code analysis cannot detect that.")]
         private class Family
         {
             public Family(IEnumerable<string> firstNames)
@@ -606,7 +605,6 @@ namespace Spritely.Recipes.Test
             public IReadOnlyCollection<string> FirstNames { get; }
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Class is used but is constructed via reflection and code analysis cannot detect that.")]
         private class Friends
         {
             public Friends(IReadOnlyCollection<string> firstNames)
@@ -619,6 +617,7 @@ namespace Spritely.Recipes.Test
                 FirstNames = firstNames;
             }
 
+            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Property is used via reflection and code analysis cannot detect that ")]
             public IEnumerable<string> FirstNames { get; }
         }
     }

--- a/Recipes/CamelStrictConstructorContractResolver/CamelStrictConstructorContractResolver.cs
+++ b/Recipes/CamelStrictConstructorContractResolver/CamelStrictConstructorContractResolver.cs
@@ -11,6 +11,7 @@
 namespace Spritely.Recipes
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.Reflection;
 
@@ -50,6 +51,39 @@ namespace Spritely.Recipes
             {
                 return ContractResolverInstance;
             }
+        }
+
+        /// <inheritdoc />
+        protected override IList<JsonProperty> CreateConstructorParameters(ConstructorInfo constructor, JsonPropertyCollection memberProperties)
+        {
+            var constructorParameters = constructor.GetParameters();
+
+            JsonPropertyCollection parameterCollection = new JsonPropertyCollection(constructor.DeclaringType);
+
+            foreach (ParameterInfo parameterInfo in constructorParameters)
+            {
+                JsonProperty matchingMemberProperty = (parameterInfo.Name != null) ? memberProperties.GetClosestMatchProperty(parameterInfo.Name) : null;
+
+                // Constructor type must be assignable from property type.
+                // Note that this is the only difference between this method and the method it overrides in DefaultContractResolver.
+                // In DefaultContractResolver, the types must match exactly.
+                if (matchingMemberProperty != null && !parameterInfo.ParameterType.IsAssignableFrom(matchingMemberProperty.PropertyType))
+                {
+                    matchingMemberProperty = null;
+                }
+
+                if (matchingMemberProperty != null || parameterInfo.Name != null)
+                {
+                    JsonProperty property = CreatePropertyFromConstructorParameter(matchingMemberProperty, parameterInfo);
+
+                    if (property != null)
+                    {
+                        parameterCollection.AddProperty(property);
+                    }
+                }
+            }
+
+            return parameterCollection;
         }
 
         /// <inheritdoc />

--- a/Recipes/CamelStrictConstructorContractResolver/CamelStrictConstructorContractResolver.cs
+++ b/Recipes/CamelStrictConstructorContractResolver/CamelStrictConstructorContractResolver.cs
@@ -54,6 +54,8 @@ namespace Spritely.Recipes
         }
 
         /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0", Justification = "This method is largely a copy-paste of the method it overrides, and that method does not validate arguments.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "1", Justification = "This method is largely a copy-paste of the method it overrides, and that method does not validate arguments.")]
         protected override IList<JsonProperty> CreateConstructorParameters(ConstructorInfo constructor, JsonPropertyCollection memberProperties)
         {
             var constructorParameters = constructor.GetParameters();

--- a/Recipes/JsonConfiguration/JsonConfiguration.nuspec
+++ b/Recipes/JsonConfiguration/JsonConfiguration.nuspec
@@ -18,7 +18,7 @@
             <group targetFramework="net450">
                 <dependency id="Spritely.Recipes.SecureStringJsonConverter" version="0.4.0" />
                 <dependency id="Spritely.Recipes.InheritedTypeJsonConverter" version="0.8.0" />
-                <dependency id="Spritely.Recipes.CamelStrictConstructorContractResolver" version="0.3.0" />
+                <dependency id="Spritely.Recipes.CamelStrictConstructorContractResolver" version="0.3.1" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
             </group>
         </dependencies>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
   version_securestring: 1.0.0
   version_securestringjsonconverter: 0.4.0
   version_inheritedtypejsonconverter: 0.8.0
-  version_camelstrictconstructorresolver: 0.3.0
-  version_jsonconfiguration: 0.14.1
+  version_camelstrictconstructorresolver: 0.3.1
+  version_jsonconfiguration: 0.14.2
   version_formattablestring: 0.1.5
   version_progressreporter: 0.3.1
   version_base64urlextensions: 0.1.1


### PR DESCRIPTION
When Newtonsoft serializes and deserializes types with constructors, it looks for a matching property for each constructor parameter.  Out-of-the-box, it considers "matching" as having the same name (case-insensitive) and having the same type.  So for example, if your constructor parameter "firstNames" is of type IEnumerable<string> and your property "FirstNames" is of type IReadOnlyCollection<string> (because the constructor copies the elements into a read only collection), then Newtonsoft does NOT consider this a match and will throw JsonSerializationException.  I've relaxed this constraint and allowed the match if the property type is assignable to the constructor type.