### PR TITLE
bug fix: not handling case when inherited type constructor throws an exception

### DIFF
--- a/Recipes.Test/JsonConfiguration/JsonConfigurationTest.cs
+++ b/Recipes.Test/JsonConfiguration/JsonConfigurationTest.cs
@@ -463,6 +463,19 @@ namespace Spritely.Recipes.Test
             Assert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(friends, JsonConfiguration.DefaultSerializerSettings));
         }
 
+        [Test]
+        public void Serializer_deserializes_type_where_constructor_does_not_throw_exception_when_another_candidate_has_constructor_that_does_throw_exception()
+        {
+            var sometimesThrowsJson = "{\"triggerNumber\":123456}";
+
+            var doesNotThrow =
+                JsonConvert.DeserializeObject<SometimesThrows>(sometimesThrowsJson,
+                    JsonConfiguration.DefaultSerializerSettings) as DoesNotThrow;
+            
+            Assert.That(doesNotThrow, Is.Not.Null);
+            Assert.That(doesNotThrow.TriggerNumber, Is.EqualTo(123456));
+        }
+
         private class CamelCasedPropertyTest
         {
             public string TestName;
@@ -619,6 +632,38 @@ namespace Spritely.Recipes.Test
 
             [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Property is used via reflection and code analysis cannot detect that ")]
             public IEnumerable<string> FirstNames { get; }
+        }
+
+        [Bindable(true)]
+        private abstract class SometimesThrows
+        {
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Class is used but is constructed via reflection and code analysis cannot detect that.")]
+        private class DoesNotThrow : SometimesThrows
+        {
+            public DoesNotThrow(int triggerNumber)
+            {
+                TriggerNumber = triggerNumber;
+            }
+
+            public int TriggerNumber { get; set; }
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Class is used but is constructed via reflection and code analysis cannot detect that.")]
+        private class DoesThrow : SometimesThrows
+        {
+            public DoesThrow(int triggerNumber)
+            {
+                if (triggerNumber == 123456)
+                {
+                    throw new ArgumentException("hit the trigger!");
+                }
+
+                TriggerNumber = triggerNumber;
+            }
+
+            public int TriggerNumber { get; set; }
         }
     }
 }

--- a/Recipes/InheritedTypeJsonConverter/InheritedTypeJsonConverter.cs
+++ b/Recipes/InheritedTypeJsonConverter/InheritedTypeJsonConverter.cs
@@ -202,7 +202,10 @@ namespace Spritely.Recipes
                 {
                     deserializedObject = serializer.Deserialize(jsonObject.CreateReader(), candidateChildType.Type);                    
                 }
-                catch (Exception)
+                catch (JsonException)
+                {
+                }
+                catch (ArgumentException)
                 {
                 }
 

--- a/Recipes/InheritedTypeJsonConverter/InheritedTypeJsonConverter.cs
+++ b/Recipes/InheritedTypeJsonConverter/InheritedTypeJsonConverter.cs
@@ -202,7 +202,7 @@ namespace Spritely.Recipes
                 {
                     deserializedObject = serializer.Deserialize(jsonObject.CreateReader(), candidateChildType.Type);                    
                 }
-                catch (JsonException)
+                catch (Exception)
                 {
                 }
 

--- a/Recipes/JsonConfiguration/JsonConfiguration.nuspec
+++ b/Recipes/JsonConfiguration/JsonConfiguration.nuspec
@@ -17,7 +17,7 @@
         <dependencies>
             <group targetFramework="net450">
                 <dependency id="Spritely.Recipes.SecureStringJsonConverter" version="0.4.0" />
-                <dependency id="Spritely.Recipes.InheritedTypeJsonConverter" version="0.8.0" />
+                <dependency id="Spritely.Recipes.InheritedTypeJsonConverter" version="0.8.1" />
                 <dependency id="Spritely.Recipes.CamelStrictConstructorContractResolver" version="0.3.1" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
             </group>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 # It is a continuously incrementing number so when used it violates the reset
 # smaller build parts rule of semantic versioning. Therefore we introduce a
 # second environment variable semantic_version.
-version: 0.20.0.{build}
+version: 0.20.1.{build}
 
 os: Visual Studio 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ environment:
   version_functional: 0.2.6
   version_securestring: 1.0.0
   version_securestringjsonconverter: 0.4.0
-  version_inheritedtypejsonconverter: 0.8.0
+  version_inheritedtypejsonconverter: 0.8.1
   version_camelstrictconstructorresolver: 0.3.1
-  version_jsonconfiguration: 0.14.2
+  version_jsonconfiguration: 0.14.3
   version_formattablestring: 0.1.5
   version_progressreporter: 0.3.1
   version_base64urlextensions: 0.1.1


### PR DESCRIPTION
catching JsonException is not sufficient.  whatever exception gets thrown by the constructor is bubbled-up to the caller, per testing and per Json.net documentation.